### PR TITLE
Update Building-an-NFT-game-using-TDD-with-Hardhat.md

### DIFF
--- a/Building-an-NFT-game-using-TDD-with-Hardhat.md
+++ b/Building-an-NFT-game-using-TDD-with-Hardhat.md
@@ -104,50 +104,67 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 
 contract AvatarArena is ERC721, ERC721Enumerable, ERC721URIStorage, Ownable {
-	using Counters for Counters.Counter;
+    using Counters for Counters.Counter;
 
-	Counters.Counter private _tokenIdCounter;
+    Counters.Counter private _tokenIdCounter;
 
-	constructor() ERC721("AvatarArena", "AVR") {}
+    string private _name;
+    string private _symbol;
 
-	function safeMint(address to, string memory uri) public onlyOwner {
-    	uint256 tokenId = _tokenIdCounter.current();
-    	_tokenIdCounter.increment();
-    	_safeMint(to, tokenId);
-    	_setTokenURI(tokenId, uri);
-	}
+    constructor(string memory name_, string memory symbol_) ERC721(name_, symbol_) {
+        _name = name_;
+        _symbol = symbol_;
+    }
 
-	// The following functions are overrides required by Solidity.
+    function safeMint(address to, string memory uri) public onlyOwner returns (uint256) {
+        require(bytes(uri).length > 0, "AvatarArena: URI must not be empty");
+        uint256 tokenId = _tokenIdCounter.current();
+        _tokenIdCounter.increment();
+        _safeMint(to, tokenId);
+        _setTokenURI(tokenId, uri);
+        return tokenId;
+    }
 
-	function _beforeTokenTransfer(address from, address to, uint256 tokenId, uint256 batchSize)
-    	internal
-    	override(ERC721, ERC721Enumerable)
-	{
-    	super._beforeTokenTransfer(from, to, tokenId, batchSize);
-	}
+    // The following functions are overrides required by Solidity.
 
-	function _burn(uint256 tokenId) internal override(ERC721, ERC721URIStorage) {
-    	super._burn(tokenId);
-	}
+    function _beforeTokenTransfer(address from, address to, uint256 tokenId)
+        internal
+        override(ERC721, ERC721Enumerable)
+    {
+        super._beforeTokenTransfer(from, to, tokenId);
+    }
 
-	function tokenURI(uint256 tokenId)
-    	public
-    	view
-    	override(ERC721, ERC721URIStorage)
-    	returns (string memory)
-	{
-    	return super.tokenURI(tokenId);
-	}
+    function _burn(uint256 tokenId) internal override(ERC721, ERC721URIStorage) {
+        super._burn(tokenId);
+    }
 
-	function supportsInterface(bytes4 interfaceId)
-    	public
-    	view
-    	override(ERC721, ERC721Enumerable)
-    	returns (bool)
-	{
-    	return super.supportsInterface(interfaceId);
-	}
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        override(ERC721, ERC721URIStorage)
+        returns (string memory)
+    {
+        return super.tokenURI(tokenId);
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(ERC721, ERC721Enumerable)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
 }
+
 ```
 
 We'll update the code to remove the `onlyOwner` modifier. It prevents anybody who's not the owner of the contract mint tokens but we don't want that restriction in our game. In our game, any user can mint a token. The updated snippet becomes:


### PR DESCRIPTION
Fixed a few unnecessary things

1. The batchSize parameter in the _beforeTokenTransfer function does not seem to be used anywhere and could be removed.

2. The supportsInterface function overrides the same function from both ERC721 and ERC721Enumerable. Since ERC721Enumerable is an extension of ERC721, it is not necessary to override the same function twice.

3. The safeMint function does not return anything. It might be useful to return the tokenId that was minted, especially if the caller needs to perform additional operations with it.

4. It might be useful to add some additional checks to ensure that the uri parameter passed to safeMint is not an empty string or contains invalid characters, as this could cause issues with the storage of token metadata.

5. The name "AvatarArena" and symbol "AVR" used in the constructor could be made customizable by passing them as parameters, in case the contract needs to be used for different types of NFTs.